### PR TITLE
Remove comma from capture group

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -63,7 +63,7 @@
         'name': 'punctuation.definition.string.end.yaml'
       '11':
         'name': 'string.unquoted.yaml'
-    'match': '(?:(?:(-\\s*)?(\\w+\\s*(:)))|(-))\\s*(?:((")[^"]*("))|((\')[^\']*(\'))|([^,{}&#\\[\\]]+))\\s*'
+    'match': '(?:(?:(-\\s*)?(\\w+\\s*(:)))|(-))\\s*(?:((")[^"]*("))|((\')[^\']*(\'))|([^{}&#\\[\\]]+))\\s*'
     'name': 'string.unquoted.yaml'
   }
   {


### PR DESCRIPTION
Commas were being interpreted as the end of a string, but they are valid within a quoted or unquoted 'scalar'
**Before**
![before](https://cloud.githubusercontent.com/assets/572843/3269814/7c366af6-f2f5-11e3-8091-8d351fc4a154.png)
**After**
![after](https://cloud.githubusercontent.com/assets/572843/3269815/7c619f3c-f2f5-11e3-9861-01d59bdff85d.png)
