### PR TITLE
Detect cloud-config files as yaml

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -6,6 +6,7 @@
   'yaml'
   'yml'
 ]
+'firstLineMatch': '^#cloud-config'
 'patterns': [
   {
     'include': '#erb'


### PR DESCRIPTION
These are specified to start with #cloud-config, and to be yaml.

http://cloudinit.readthedocs.org/en/latest/topics/format.html#cloud-config-data
https://github.com/coreos/coreos-cloudinit
