### PR TITLE
Handle unindented empty lines in text block

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -21,7 +21,7 @@
         'name': 'entity.name.tag.yaml'
       '5':
         'name': 'punctuation.separator.key-value.yaml'
-    'end': '^(?!^\\1)|^(?=\\1(-|\\w+\\s*:)|#)'
+    'end': '^(?!\\1\\s+)(?=\\s*(-|\\w+\\s*:)|#)'
     'name': 'string.unquoted.block.yaml'
     'patterns': [
       {

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -56,6 +56,106 @@ describe "YAML grammar", ->
         expect(tokens[7]).toEqual value: "\\'", scopes: ["source.yaml", "string.unquoted.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
         expect(tokens[8]).toEqual value: "'", scopes: ["source.yaml", "string.unquoted.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
 
+    describe "text blocks", ->
+      it "parses simple content", ->
+        lines = grammar.tokenizeLines """
+        key: |
+          content here
+          second line
+        """
+        expect(lines[0][0]).toEqual value: "key", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml"]
+        expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[1][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+        expect(lines[2][0]).toEqual value: "  second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+
+      it "parses content with empty lines", ->
+        lines = grammar.tokenizeLines """
+        key: |
+          content here
+
+          second line
+        """
+        expect(lines[0][0]).toEqual value: "key", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml"]
+        expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[1][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+        expect(lines[2][0]).toEqual value: "", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+        expect(lines[3][0]).toEqual value: "  second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+
+      describe "parses content with unindented empty lines", ->
+        it "ending the content", ->
+          lines = grammar.tokenizeLines """
+          key: |
+            content here
+
+            second line
+          """
+          expect(lines[0][0]).toEqual value: "key", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml"]
+          expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+          expect(lines[0][2]).toEqual value: " |", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[1][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[2][0]).toEqual value: "", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[3][0]).toEqual value: "  second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+
+        it "ending with new element", ->
+          lines = grammar.tokenizeLines """
+          key: |
+            content here
+
+            second line
+          other: hi
+          """
+          expect(lines[0][0]).toEqual value: "key", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml"]
+          expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+          expect(lines[0][2]).toEqual value: " |", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[1][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[2][0]).toEqual value: "", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[3][0]).toEqual value: "  second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[4][0]).toEqual value: "other", scopes: ["source.yaml", "string.unquoted.yaml", "entity.name.tag.yaml"]
+          expect(lines[4][1]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+          expect(lines[4][2]).toEqual value: " ", scopes: ["source.yaml", "string.unquoted.yaml"]
+          expect(lines[4][3]).toEqual value: "hi", scopes: ["source.yaml", "string.unquoted.yaml", "string.unquoted.yaml"]
+
+        it "ending with new element, part of list", ->
+          lines = grammar.tokenizeLines """
+           - key: |
+               content here
+
+               second line
+           - other: hi
+          """
+          expect(lines[0][0]).toEqual value: "- ", scopes: ["source.yaml", "string.unquoted.block.yaml", "punctuation.definition.entry.yaml"]
+          expect(lines[0][1]).toEqual value: "key", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml"]
+          expect(lines[0][2]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+          expect(lines[0][3]).toEqual value: " |", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[1][0]).toEqual value: "    content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[2][0]).toEqual value: "", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[3][0]).toEqual value: "    second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[4][0]).toEqual value: "- ", scopes: ["source.yaml", "string.unquoted.yaml", "punctuation.definition.entry.yaml"]
+          expect(lines[4][1]).toEqual value: "other", scopes: ["source.yaml", "string.unquoted.yaml", "entity.name.tag.yaml"]
+          expect(lines[4][2]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+          expect(lines[4][3]).toEqual value: " ", scopes: ["source.yaml", "string.unquoted.yaml"]
+          expect(lines[4][4]).toEqual value: "hi", scopes: ["source.yaml", "string.unquoted.yaml", "string.unquoted.yaml"]
+
+        it "ending with twice unindented new element", ->
+          lines = grammar.tokenizeLines """
+          root:
+            key: |
+              content here
+
+              second line
+          other: hi
+          """
+          expect(lines[1][1]).toEqual value: "key", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml"]
+          expect(lines[1][2]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.block.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+          expect(lines[1][3]).toEqual value: " |", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[2][0]).toEqual value: "    content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[3][0]).toEqual value: "", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[4][0]).toEqual value: "    second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+          expect(lines[5][0]).toEqual value: "other", scopes: ["source.yaml", "string.unquoted.yaml", "entity.name.tag.yaml"]
+          expect(lines[5][1]).toEqual value: ":", scopes: ["source.yaml", "string.unquoted.yaml", "entity.name.tag.yaml", "punctuation.separator.key-value.yaml"]
+          expect(lines[5][2]).toEqual value: " ", scopes: ["source.yaml", "string.unquoted.yaml"]
+          expect(lines[5][3]).toEqual value: "hi", scopes: ["source.yaml", "string.unquoted.yaml", "string.unquoted.yaml"]
+
   it "parses the leading ! before values", ->
     {tokens} = grammar.tokenizeLine("key: ! 'hi'")
     expect(tokens[0]).toEqual value: "key", scopes: ["source.yaml", "string.unquoted.yaml", "entity.name.tag.yaml"]


### PR DESCRIPTION
Handle text blocks properly. As can be seen here, the GitHub renderer correctly marks the `content: |` text block as a block:

``` yaml
#cloud-config

coreos:
  etcd:
    # generate a new token for each unique cluster from https://discovery.etcd.io/new
    # WARNING: replace each time you 'vagrant destroy'
    #discovery: https://discovery.etcd.io/<token>
    addr: $public_ipv4:4001
    peer-addr: $public_ipv4:7001
  fleet:
    public-ip: $public_ipv4
  units:
    - name: etcd.service
      command: start
    - name: fleet.service
      command: start
    - name: docker-tcp.socket
      command: start
      enable: true
      content: |
        [Unit]
        Description=Docker Socket for the API

        [Socket]
        ListenStream=2375
        Service=docker.service
        BindIPv6Only=both

        [Install]
        WantedBy=sockets.target
      hi:

```

language-yaml doesn't handle this properly:

<img src="https://cloud.githubusercontent.com/assets/660706/4689469/b6195f5a-56bc-11e4-86f3-97c3dab759e8.png" width="400" alt="Old">

This PR changes it to be correct:

<img src="https://cloud.githubusercontent.com/assets/660706/4689470/bddd9e5e-56bc-11e4-9fa6-aaa1aa71f10f.png" width="400" alt="Fixed">

The correct "AST" can be viewed here: http://yaml-online-parser.appspot.com/
