### PR TITLE
Add support for SaltStack states files

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -5,6 +5,7 @@
   'eyml'
   'yaml'
   'yml'
+  'sls'
 ]
 'firstLineMatch': '^#cloud-config'
 'patterns': [


### PR DESCRIPTION
SaltStack uses the YAML syntax to define states (ref: http://docs.saltstack.com/en/latest/topics/tutorials/starting_states.html ), with file extension `.sls`.

This change allows `language-yaml` to recognize those files based on the file extension `.sls`.