### PR TITLE
Boxfile support (Pagodabox)

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -8,6 +8,7 @@
   'yml'
   'sls'
   'sublime-syntax'
+  'Boxfile'
 ]
 'firstLineMatch': '^#cloud-config'
 'patterns': [


### PR DESCRIPTION
PagodaBox (https://pagodabox.io/) uses YAML for service configuration. The filename is Boxfile, not *.Boxfile.