### PR TITLE
Another large rewrite

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -98,6 +98,20 @@
     'match': '(?:(?:(?:(-))?\\s*([^!{@#%&*>,\'"][^#\'"]*?)(:))|(-))\\s+(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
   }
   {
+    'captures':
+      '1':
+        'name': 'entity.name.tag.merge.yaml'
+      '2':
+        'name': 'punctuation.separator.key-value.yaml'
+      '3':
+        'patterns': [
+          {
+            'include': '#variables'
+          }
+        ]
+    'match': '(<<)\\s*(:)\\s+(.+)$'
+  }
+  {
     'begin': '(?>^\\s*(-)?\\s*)([^!{@#%&*>,\'"][^#\'"]*?)(:)\\s+((!!)omap)?'
     'beginCaptures':
       '1':
@@ -198,25 +212,10 @@
     ]
   }
   {
-    'captures':
-      '1':
-        'name': 'punctuation.definition.variable.yaml'
-    'match': '(&|\\*)\\w+$'
-    'name': 'variable.other.yaml'
+    'include': '#variables'
   }
   {
     'include': '#strings'
-  }
-  {
-    'captures':
-      '1':
-        'name': 'entity.name.tag.yaml'
-      '2':
-        'name': 'keyword.operator.merge-key.yaml'
-      '3':
-        'name': 'punctuation.definition.keyword.yaml'
-    'match': '(\\<\\<): ((\\*).*)$'
-    'name': 'keyword.operator.merge-key.yaml'
   }
 ]
 'repository':
@@ -322,3 +321,9 @@
         'name': 'string.unquoted.yaml'
       }
     ]
+  'variables':
+    'captures':
+      '1':
+        'name': 'punctuation.definition.variable.yaml'
+    'match': '(&|\\*)\\w+$'
+    'name': 'variable.other.yaml'

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -208,25 +208,6 @@
     'include': '#strings'
   }
   {
-    'begin': '`'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.yaml'
-    'end': '`'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.yaml'
-    'name': 'string.interpolated.yaml'
-    'patterns': [
-      {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#erb'
-      }
-    ]
-  }
-  {
     'captures':
       '1':
         'name': 'entity.name.tag.yaml'
@@ -332,6 +313,25 @@
           '0':
             'name': 'punctuation.definition.string.end.yaml'
         'name': 'string.quoted.single.yaml'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#erb'
+          }
+        ]
+      }
+      {
+        'begin': '`'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.yaml'
+        'end': '`'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.yaml'
+        'name': 'string.interpolated.yaml'
         'patterns': [
           {
             'include': '#escaped_char'

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -105,7 +105,7 @@
       '4':
         'name': 'keyword.other.omap.yaml'
       '5':
-        'name': 'punctuation.definition.keyword.yaml'
+        'name': 'punctuation.definition.tag.omap.yaml'
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
     'patterns': [
       {
@@ -142,7 +142,7 @@
       '11':
         'name': 'keyword.other.omap.yaml'
       '12':
-        'name': 'punctuation.definition.keyword.yaml'
+        'name': 'punctuation.definition.tag.omap.yaml'
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
     'patterns': [
       {
@@ -161,7 +161,7 @@
       '2':
         'name': 'keyword.other.omap.yaml'
       '3':
-        'name': 'punctuation.definition.keyword.yaml'
+        'name': 'punctuation.definition.tag.omap.yaml'
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:))'
     'patterns': [
       {

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -99,23 +99,7 @@
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
     'patterns': [
       {
-        'include': '#comment'
-      }
-      {
-        'match': '!(?=\\s)'
-        'name': 'punctuation.definition.tag.non-specific.yaml'
-      }
-      {
-        'include': '#constants'
-      }
-      {
-        'include': '#date'
-      }
-      {
-        'include': '#numeric'
-      }
-      {
-        'include': '#strings'
+        'include': '#scalar-content'
       }
     ]
   }
@@ -149,23 +133,7 @@
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
     'patterns': [
       {
-        'include': '#comment'
-      }
-      {
-        'match': '!(?=\\s)'
-        'name': 'punctuation.definition.tag.non-specific.yaml'
-      }
-      {
-        'include': '#constants'
-      }
-      {
-        'include': '#date'
-      }
-      {
-        'include': '#numeric'
-      }
-      {
-        'include': '#strings'
+        'include': '#scalar-content'
       }
     ]
   }
@@ -181,23 +149,7 @@
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:))'
     'patterns': [
       {
-        'include': '#comment'
-      }
-      {
-        'match': '!(?=\\s)'
-        'name': 'punctuation.definition.tag.non-specific.yaml'
-      }
-      {
-        'include': '#constants'
-      }
-      {
-        'include': '#date'
-      }
-      {
-        'include': '#numeric'
-      }
-      {
-        'include': '#strings'
+        'include': '#scalar-content'
       }
     ]
   }
@@ -319,6 +271,28 @@
       {
         'match': '[^\\s"\'\\n](?!\\s*#(?!{))([^#\\n]|((?<!\\s)#))*'
         'name': 'string.unquoted.yaml'
+      }
+    ]
+  'scalar-content':
+    'patterns': [
+      {
+        'include': '#comment'
+      }
+      {
+        'match': '!(?=\\s)'
+        'name': 'punctuation.definition.tag.non-specific.yaml'
+      }
+      {
+        'include': '#constants'
+      }
+      {
+        'include': '#date'
+      }
+      {
+        'include': '#numeric'
+      }
+      {
+        'include': '#strings'
       }
     ]
   'variables':

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -19,6 +19,9 @@
     'include': '#erb'
   }
   {
+    'include': '#comment'
+  }
+  {
     'match': '\\t+'
     'name': 'invalid.illegal.whitespace.yaml'
   }
@@ -120,14 +123,7 @@
         'include': '#constants'
       }
       {
-        'include': '#double_quoted_string'
-      }
-      {
-        'include': '#single_quoted_string'
-      }
-      {
-        'match': '[^"\'\\n](?!#(?!{))([^#\\n]|((?<!\\s)#))*'
-        'name': 'string.unquoted.yaml'
+        'include': '#strings'
       }
     ]
   }
@@ -171,14 +167,7 @@
         'include': '#constants'
       }
       {
-        'include': '#double_quoted_string'
-      }
-      {
-        'include': '#single_quoted_string'
-      }
-      {
-        'match': '[^"\'\\n](?!#(?!{))([^#\\n]|((?<!\\s)#))*'
-        'name': 'string.unquoted.yaml'
+        'include': '#strings'
       }
     ]
   }
@@ -204,14 +193,7 @@
         'include': '#constants'
       }
       {
-        'include': '#double_quoted_string'
-      }
-      {
-        'include': '#single_quoted_string'
-      }
-      {
-        'match': '[^"\'\\n](?!#(?!{))([^#\\n]|((?<!\\s)#))*'
-        'name': 'string.unquoted.yaml'
+        'include': '#strings'
       }
     ]
   }
@@ -223,10 +205,7 @@
     'name': 'variable.other.yaml'
   }
   {
-    'include': '#double_quoted_string'
-  }
-  {
-    'include': '#single_quoted_string'
+    'include': '#strings'
   }
   {
     'begin': '`'
@@ -262,23 +241,6 @@
     'disabled': '1'
     'match': '( |\t)+$'
     'name': 'invalid.deprecated.trailing-whitespace.yaml'
-  }
-  {
-    'begin': '(^[ \\t]+)?(?<!\\$)(?<=^|[ \\t])(?=#)(?!#{)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.yaml'
-    'end': '(?!\\G)'
-    'patterns': [
-      {
-        'begin': '#'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.yaml'
-        'end': '\\n'
-        'name': 'comment.line.number-sign.yaml'
-      }
-    ]
   }
   {
     'match': '-'
@@ -339,39 +301,48 @@
   'escaped_char':
     'match': '\\\\.'
     'name': 'constant.character.escape.yaml'
-  'double_quoted_string':
-    'begin': '"'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.yaml'
-    'end': '"'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.yaml'
-    'name': 'string.quoted.double.yaml'
+  'strings':
     'patterns': [
       {
-        'include': '#escaped_char'
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.yaml'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.yaml'
+        'name': 'string.quoted.double.yaml'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#erb'
+          }
+        ]
       }
       {
-        'include': '#erb'
+        'begin': '\''
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.yaml'
+        'end': '\''
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.yaml'
+        'name': 'string.quoted.single.yaml'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#erb'
+          }
+        ]
       }
-    ]
-  'single_quoted_string':
-    'begin': '\''
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.yaml'
-    'end': '\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.yaml'
-    'name': 'string.quoted.single.yaml'
-    'patterns': [
       {
-        'include': '#escaped_char'
-      }
-      {
-        'include': '#erb'
+        'match': '[^"\'\\n](?!\\s*#(?!{))([^#\\n]|((?<!\\s)#))*'
+        'name': 'string.unquoted.yaml'
       }
     ]

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -110,12 +110,7 @@
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
     'patterns': [
       {
-        'match': '(?<=^|\\s)((#(?!{)).*)'
-        'captures':
-          '1':
-            'name': 'comment.line.number-sign.yaml'
-          '2':
-            'name': 'punctuation.definition.comment.yaml'
+        'include': '#comment'
       }
       {
         'match': '\\!\\s*'
@@ -166,12 +161,7 @@
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
     'patterns': [
       {
-        'match': '(?<=^|\\s)((#(?!{)).*)'
-        'captures':
-          '1':
-            'name': 'comment.line.number-sign.yaml'
-          '2':
-            'name': 'punctuation.definition.comment.yaml'
+        'include': '#comment'
       }
       {
         'match': '\\!\\s*'
@@ -204,12 +194,7 @@
     'end': '(?=^\\s*(-|[^!{@#%&*>,].*:))'
     'patterns': [
       {
-        'match': '(?<=^|\\s)((#(?!{)).*)'
-        'captures':
-          '1':
-            'name': 'comment.line.number-sign.yaml'
-          '2':
-            'name': 'punctuation.definition.comment.yaml'
+        'include': '#comment'
       }
       {
         'match': '\\!\\s*'
@@ -316,6 +301,13 @@
   }
 ]
 'repository':
+  'comment':
+    'match': '(?<=^|\\s)((#(?!{)).*)'
+    'captures':
+      '1':
+        'name': 'comment.line.number-sign.yaml'
+      '2':
+        'name': 'punctuation.definition.comment.yaml'
   'constants':
     'match': '(?<=\\s)(true|false|null)(?=\\s*$)'
     'name': 'constant.language.yaml'

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -72,34 +72,6 @@
   {
     'captures':
       '1':
-        'name': 'punctuation.definition.entry.yaml'
-      '2':
-        'name': 'entity.name.tag.yaml'
-      '3':
-        'name': 'punctuation.separator.key-value.yaml'
-      '4':
-        'name': 'punctuation.definition.entry.yaml'
-      '5':
-        'name': 'constant.other.date.yaml'
-    'match': '(?:(?:(-)?\\s*([^!{@#%&*>,\'"][^#\'"]*?)(:))|(-))\\s+([0-9]{4}-[0-9]{2}-[0-9]{2})\\s*($|(?=#)(?!#{))'
-  }
-  {
-    'captures':
-      '1':
-        'name': 'punctuation.definition.entry.yaml'
-      '2':
-        'name': 'entity.name.tag.yaml'
-      '3':
-        'name': 'punctuation.separator.key-value.yaml'
-      '4':
-        'name': 'punctuation.definition.entry.yaml'
-      '5':
-        'name': 'constant.numeric.yaml'
-    'match': '(?:(?:(?:(-))?\\s*([^!{@#%&*>,\'"][^#\'"]*?)(:))|(-))\\s+(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
-  }
-  {
-    'captures':
-      '1':
         'name': 'entity.name.tag.merge.yaml'
       '2':
         'name': 'punctuation.separator.key-value.yaml'
@@ -135,6 +107,12 @@
       }
       {
         'include': '#constants'
+      }
+      {
+        'include': '#date'
+      }
+      {
+        'include': '#numeric'
       }
       {
         'include': '#strings'
@@ -181,6 +159,12 @@
         'include': '#constants'
       }
       {
+        'include': '#date'
+      }
+      {
+        'include': '#numeric'
+      }
+      {
         'include': '#strings'
       }
     ]
@@ -207,6 +191,12 @@
         'include': '#constants'
       }
       {
+        'include': '#date'
+      }
+      {
+        'include': '#numeric'
+      }
+      {
         'include': '#strings'
       }
     ]
@@ -229,6 +219,11 @@
   'constants':
     'match': '(?<=\\s)(true|false|null)(?=\\s*$)'
     'name': 'constant.language.yaml'
+  'date':
+    'match': '([0-9]{4}-[0-9]{2}-[0-9]{2})\\s*($|(?=#)(?!#{))'
+    'captures':
+      '1':
+        'name': 'constant.other.date.yaml'
   'erb':
     'begin': '<%+(?!>)=?'
     'beginCaptures':
@@ -257,6 +252,11 @@
   'escaped_char':
     'match': '\\\\.'
     'name': 'constant.character.escape.yaml'
+  'numeric':
+    'match': '(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
+    'captures':
+      '1':
+        'name': 'constant.numeric.yaml'
   'strings':
     'patterns': [
       {

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -77,12 +77,11 @@
       '4':
         'name': 'punctuation.definition.entry.yaml'
       '5':
-        'name': 'constant.numeric.yaml'
-    'match': '(?:(?:(?:(-))?\\s*([^#\'"][^#\'"]*?)(:)(?=\\s))|(-))\\s*(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
+        'name': 'constant.other.date.yaml'
+    'match': '(?:(?:(-)?\\s*([^!{@#%&*>,\'"][^#\'"]*?)(:))|(-))\\s+([0-9]{4}-[0-9]{2}-[0-9]{2})\\s*($|(?=#)(?!#{))'
   }
   {
-    'begin': '(?:(?:(?:(-))?\\s*([^#\'"][^#\'"]*?)(:)(?=\\s))|(-))[ ]*'
-    'beginCaptures':
+    'captures':
       '1':
         'name': 'punctuation.definition.entry.yaml'
       '2':
@@ -91,7 +90,24 @@
         'name': 'punctuation.separator.key-value.yaml'
       '4':
         'name': 'punctuation.definition.entry.yaml'
-    'end': '(?=^\\s*(-|[^!@#%&*>,].*:))'
+      '5':
+        'name': 'constant.numeric.yaml'
+    'match': '(?:(?:(?:(-))?\\s*([^!{@#%&*>,\'"][^#\'"]*?)(:))|(-))\\s+(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
+  }
+  {
+    'begin': '(?>^\\s*(-)?\\s*)([^!{@#%&*>,\'"][^#\'"]*?)(:)\\s+((!!)omap)?'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.entry.yaml'
+      '2':
+        'name': 'entity.name.tag.yaml'
+      '3':
+        'name': 'punctuation.separator.key-value.yaml'
+      '4':
+        'name': 'keyword.other.omap.yaml'
+      '5':
+        'name': 'punctuation.definition.keyword.yaml'
+    'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
     'patterns': [
       {
         'match': '(?<=^|\\s)((#(?!{)).*)'
@@ -121,7 +137,7 @@
     ]
   }
   {
-    'begin': '(?:(?:(?:(-))?\\s*(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)(?=\\s))|(-))[ ]*'
+    'begin': '(-)?\\s*(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)\\s+((!!)omap)?'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.entry.yaml'
@@ -144,8 +160,48 @@
       '10':
         'name': 'punctuation.separator.key-value.yaml'
       '11':
+        'name': 'keyword.other.omap.yaml'
+      '12':
+        'name': 'punctuation.definition.keyword.yaml'
+    'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
+    'patterns': [
+      {
+        'match': '(?<=^|\\s)((#(?!{)).*)'
+        'captures':
+          '1':
+            'name': 'comment.line.number-sign.yaml'
+          '2':
+            'name': 'punctuation.definition.comment.yaml'
+      }
+      {
+        'match': '\\!\\s*'
+        'name': 'string.unquoted.yaml'
+      }
+      {
+        'include': '#constants'
+      }
+      {
+        'include': '#double_quoted_string'
+      }
+      {
+        'include': '#single_quoted_string'
+      }
+      {
+        'match': '[^"\'\\n](?!#(?!{))([^#\\n]|((?<!\\s)#))*'
+        'name': 'string.unquoted.yaml'
+      }
+    ]
+  }
+  {
+    'begin': '(-)\\s+(?:((!!)omap)|(?![!@#%&*>,]))'
+    'beginCaptures':
+      '1':
         'name': 'punctuation.definition.entry.yaml'
-    'end': '(?=^\\s*(-|[^!@#%&*>,].*:))'
+      '2':
+        'name': 'keyword.other.omap.yaml'
+      '3':
+        'name': 'punctuation.definition.keyword.yaml'
+    'end': '(?=^\\s*(-|[^!{@#%&*>,].*:))'
     'patterns': [
       {
         'match': '(?<=^|\\s)((#(?!{)).*)'
@@ -177,34 +233,8 @@
   {
     'captures':
       '1':
-        'name': 'punctuation.definition.entry.yaml'
-      '2':
-        'name': 'entity.name.tag.yaml'
-      '3':
-        'name': 'punctuation.separator.key-value.yaml'
-      '4':
-        'name': 'punctuation.definition.entry.yaml'
-    'match': '(?:(?:(-)?\\s*(\\w+)\\s*(:))|(-))\\s*([0-9]{4}-[0-9]{2}-[0-9]{2})\\s*($|(?=#)(?!#\\{))'
-    'name': 'constant.other.date.yaml'
-  }
-  {
-    'captures':
-      '1':
-        'name': 'entity.name.tag.yaml'
-      '2':
-        'name': 'punctuation.separator.key-value.yaml'
-      '3':
-        'name': 'keyword.other.omap.yaml'
-      '4':
-        'name': 'punctuation.definition.keyword.yaml'
-    'match': '(\\w.*?)(:)\\s*((\\!\\!)omap)?'
-    'name': 'meta.tag.yaml'
-  }
-  {
-    'captures':
-      '1':
         'name': 'punctuation.definition.variable.yaml'
-    'match': '(\\&|\\*)\\w.*?$'
+    'match': '(&|\\*)\\w+$'
     'name': 'variable.other.yaml'
   }
   {
@@ -249,7 +279,7 @@
     'name': 'invalid.deprecated.trailing-whitespace.yaml'
   }
   {
-    'begin': '(^[ \\t]+)?(?<!\\$)(?<=^|[ \\t])(?=#)(?!#\\{)'
+    'begin': '(^[ \\t]+)?(?<!\\$)(?<=^|[ \\t])(?=#)(?!#{)'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.yaml'

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -116,8 +116,8 @@
         'include': '#comment'
       }
       {
-        'match': '\\!\\s*'
-        'name': 'string.unquoted.yaml'
+        'match': '!(?=\\s)'
+        'name': 'punctuation.definition.tag.non-specific.yaml'
       }
       {
         'include': '#constants'
@@ -160,8 +160,8 @@
         'include': '#comment'
       }
       {
-        'match': '\\!\\s*'
-        'name': 'string.unquoted.yaml'
+        'match': '!(?=\\s)'
+        'name': 'punctuation.definition.tag.non-specific.yaml'
       }
       {
         'include': '#constants'
@@ -186,8 +186,8 @@
         'include': '#comment'
       }
       {
-        'match': '\\!\\s*'
-        'name': 'string.unquoted.yaml'
+        'match': '!(?=\\s)'
+        'name': 'punctuation.definition.tag.non-specific.yaml'
       }
       {
         'include': '#constants'
@@ -342,7 +342,7 @@
         ]
       }
       {
-        'match': '[^"\'\\n](?!\\s*#(?!{))([^#\\n]|((?<!\\s)#))*'
+        'match': '[^\\s"\'\\n](?!\\s*#(?!{))([^#\\n]|((?<!\\s)#))*'
         'name': 'string.unquoted.yaml'
       }
     ]

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -30,6 +30,8 @@
     'name': 'punctuation.definition.directives.end.yaml'
   }
   {
+    # hello: >
+    # hello: |
     'begin': '^(\\s*)(?!-\\s*)(\\S+)\\s*(:)\\s*(?=\\||>)'
     'beginCaptures':
       '2':
@@ -48,6 +50,10 @@
     ]
   }
   {
+    # - >
+    # - |
+    # - hello: >
+    # - hello: |
     'begin': '^(\\s*)(?:(-)|(?:(?:(-)\\s*)?(\\S+)\\s*(:)))\\s*(?=\\||>)'
     'beginCaptures':
       '2':
@@ -70,6 +76,8 @@
     ]
   }
   {
+    # << : *variableToMerge
+    'match': '(<<)\\s*(:)\\s+(.+)$'
     'captures':
       '1':
         'name': 'entity.name.tag.merge.yaml'
@@ -81,9 +89,11 @@
             'include': '#variables'
           }
         ]
-    'match': '(<<)\\s*(:)\\s+(.+)$'
   }
   {
+    # - hello:
+    # look at me go:
+    # omap time: !!omap
     'begin': '(?>^\\s*(-)?\\s*)([^!{@#%&*>,\'"][^#\'"]*?)(:)\\s+((!!)omap)?'
     'beginCaptures':
       '1':
@@ -104,6 +114,9 @@
     ]
   }
   {
+    # - 'quoted':
+    # "quoted":
+    # "with omap": !!omap
     'begin': '(-)?\\s*(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)\\s+((!!)omap)?'
     'beginCaptures':
       '1':
@@ -138,6 +151,9 @@
     ]
   }
   {
+    # - stuff
+    # - !!omap
+    # -
     'begin': '(-)\\s+(?:((!!)omap)|(?![!@#%&*>,]))'
     'beginCaptures':
       '1':

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -218,30 +218,6 @@
     'match': '(\\<\\<): ((\\*).*)$'
     'name': 'keyword.operator.merge-key.yaml'
   }
-  {
-    'disabled': '1'
-    'match': '( |\t)+$'
-    'name': 'invalid.deprecated.trailing-whitespace.yaml'
-  }
-  {
-    'match': '-'
-    'name': 'keyword.operator.symbol'
-  }
-  {
-    'begin': '^(?=\\t)'
-    'end': '(?=[^\\t])'
-    'name': 'meta.leading-tabs.yaml'
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'meta.odd-tab'
-          '2':
-            'name': 'meta.even-tab'
-        'match': '(\\t)(\\t)?'
-      }
-    ]
-  }
 ]
 'repository':
   'comment':

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -499,7 +499,7 @@ describe "YAML grammar", ->
     expect(tokens[0]).toEqual value: "hello", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(tokens[1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[3]).toEqual value: "!!", scopes: ["source.yaml", "keyword.other.omap.yaml", "punctuation.definition.keyword.yaml"]
+    expect(tokens[3]).toEqual value: "!!", scopes: ["source.yaml", "keyword.other.omap.yaml", "punctuation.definition.tag.omap.yaml"]
     expect(tokens[4]).toEqual value: "omap", scopes: ["source.yaml", "keyword.other.omap.yaml"]
 
     {tokens} = grammar.tokenizeLine "- 'hello': !!omap"
@@ -510,7 +510,7 @@ describe "YAML grammar", ->
     expect(tokens[4]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
     expect(tokens[5]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(tokens[6]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[7]).toEqual value: "!!", scopes: ["source.yaml", "keyword.other.omap.yaml", "punctuation.definition.keyword.yaml"]
+    expect(tokens[7]).toEqual value: "!!", scopes: ["source.yaml", "keyword.other.omap.yaml", "punctuation.definition.tag.omap.yaml"]
     expect(tokens[8]).toEqual value: "omap", scopes: ["source.yaml", "keyword.other.omap.yaml"]
 
     {tokens} = grammar.tokenizeLine "hello:!!omap"

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -141,8 +141,8 @@ describe "YAML grammar", ->
         expect(lines[0][0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
         expect(lines[0][2]).toEqual value: "textblock", scopes: ["source.yaml", "entity.name.tag.yaml"]
         expect(lines[0][3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-        expect(lines[1][0]).toEqual value: "    multiline", scopes: ["source.yaml", "string.unquoted.yaml"]
-        expect(lines[2][0]).toEqual value: "    text", scopes: ["source.yaml", "string.unquoted.yaml"]
+        expect(lines[1][1]).toEqual value: "multiline", scopes: ["source.yaml", "string.unquoted.yaml"]
+        expect(lines[2][1]).toEqual value: "text", scopes: ["source.yaml", "string.unquoted.yaml"]
         expect(lines[3][0]).toEqual value: "  ", scopes: ["source.yaml"]
         expect(lines[3][1]).toEqual value: "key", scopes: ["source.yaml", "entity.name.tag.yaml"]
         expect(lines[3][2]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
@@ -255,10 +255,10 @@ describe "YAML grammar", ->
     expect(tokens[0]).toEqual value: "key", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(tokens[1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[3]).toEqual value: "! ", scopes: ["source.yaml", "string.unquoted.yaml"]
-    expect(tokens[4]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
-    expect(tokens[5]).toEqual value: "hi", scopes: ["source.yaml", "string.quoted.single.yaml"]
-    expect(tokens[6]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml",  "punctuation.definition.string.end.yaml"]
+    expect(tokens[3]).toEqual value: "!", scopes: ["source.yaml", "punctuation.definition.tag.non-specific.yaml"]
+    expect(tokens[5]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
+    expect(tokens[6]).toEqual value: "hi", scopes: ["source.yaml", "string.quoted.single.yaml"]
+    expect(tokens[7]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml",  "punctuation.definition.string.end.yaml"]
 
   it "parses nested keys", ->
     lines = grammar.tokenizeLines """
@@ -392,11 +392,11 @@ describe "YAML grammar", ->
     """
 
     expect(lines[0][3]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
-    expect(lines[1][0]).toEqual value: "  This should still be a string ", scopes: ["source.yaml", "string.unquoted.yaml"]
-    expect(lines[1][1]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
-    expect(lines[2][0]).toEqual value: "  Ditto", scopes: ["source.yaml", "string.unquoted.yaml"]
+    expect(lines[1][1]).toEqual value: "This should still be a string ", scopes: ["source.yaml", "string.unquoted.yaml"]
+    expect(lines[1][2]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
+    expect(lines[2][1]).toEqual value: "Ditto", scopes: ["source.yaml", "string.unquoted.yaml"]
     expect(lines[3][1]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
-    expect(lines[4][0]).toEqual value: "  String", scopes: ["source.yaml", "string.unquoted.yaml"]
+    expect(lines[4][1]).toEqual value: "String", scopes: ["source.yaml", "string.unquoted.yaml"]
     expect(lines[5][0]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
 
   it "does not confuse keys and comments", ->

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -531,6 +531,22 @@ describe "YAML grammar", ->
     expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
     expect(tokens[3]).toEqual value: "2012-12-21", scopes: ["source.yaml", "constant.other.date.yaml"]
 
+    {tokens} = grammar.tokenizeLine "'the apocalypse is nigh': 2012-12-21"
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
+    expect(tokens[1]).toEqual value: "the apocalypse is nigh", scopes: ["source.yaml", "string.quoted.single.yaml", "entity.name.tag.yaml"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
+    expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+    expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
+    expect(tokens[5]).toEqual value: "2012-12-21", scopes: ["source.yaml", "constant.other.date.yaml"]
+
+    lines = grammar.tokenizeLines """
+      multiline:
+        - 2001-01-01
+        2001-01-01
+    """
+    expect(lines[1][3]).toEqual value: "2001-01-01", scopes: ["source.yaml", "constant.other.date.yaml"]
+    expect(lines[2][1]).toEqual value: "2001-01-01", scopes: ["source.yaml", "constant.other.date.yaml"]
+
     {tokens} = grammar.tokenizeLine "- 2001-01-01"
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
@@ -540,6 +556,11 @@ describe "YAML grammar", ->
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
     expect(tokens[2]).toEqual value: "07-04-1776", scopes: ["source.yaml", "string.unquoted.yaml"]
+
+    {tokens} = grammar.tokenizeLine "- nope 2001-01-01"
+    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+    expect(tokens[2]).toEqual value: "nope 2001-01-01", scopes: ["source.yaml", "string.unquoted.yaml"]
 
     {tokens} = grammar.tokenizeLine "- 2001-01-01 uh oh"
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
@@ -565,6 +586,27 @@ describe "YAML grammar", ->
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
     expect(tokens[2]).toEqual value: "0.7e-9001", scopes: ["source.yaml", "constant.numeric.yaml"]
+
+    {tokens} = grammar.tokenizeLine "'over 9000': 9001"
+    expect(tokens[0]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
+    expect(tokens[1]).toEqual value: "over 9000", scopes: ["source.yaml", "string.quoted.single.yaml", "entity.name.tag.yaml"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
+    expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+    expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
+    expect(tokens[5]).toEqual value: "9001", scopes: ["source.yaml", "constant.numeric.yaml"]
+
+    lines = grammar.tokenizeLines """
+      multiline:
+        - 3.14f
+        3.14f
+    """
+    expect(lines[1][3]).toEqual value: "3.14f", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(lines[2][1]).toEqual value: "3.14f", scopes: ["source.yaml", "constant.numeric.yaml"]
+
+    {tokens} = grammar.tokenizeLine "- pi 3.14"
+    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+    expect(tokens[2]).toEqual value: "pi 3.14", scopes: ["source.yaml", "string.unquoted.yaml"]
 
     {tokens} = grammar.tokenizeLine "- 3.14 uh oh"
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -240,7 +240,7 @@ describe "YAML grammar", ->
           expect(lines[2][0]).toEqual value: "    content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
           expect(lines[3][0]).toEqual value: "", scopes: ["source.yaml", "string.unquoted.block.yaml"]
           expect(lines[4][0]).toEqual value: "    second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
-          expect(lines[5][0]).toEqual value: "  ", scopes: ["source.yaml", "punctuation.whitespace.comment.leading.yaml"]
+          expect(lines[5][0]).toEqual value: "  ", scopes: ["source.yaml"]
           expect(lines[5][1]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
           expect(lines[5][2]).toEqual value: " hi", scopes: ["source.yaml", "comment.line.number-sign.yaml"]
 
@@ -342,7 +342,7 @@ describe "YAML grammar", ->
     expect(lines[0][0]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
     expect(lines[0][1]).toEqual value: " first: 1", scopes: ["source.yaml", "comment.line.number-sign.yaml"]
 
-    expect(lines[1][0]).toEqual value: "  ", scopes: ["source.yaml", "punctuation.whitespace.comment.leading.yaml"]
+    expect(lines[1][0]).toEqual value: "  ", scopes: ["source.yaml"]
     expect(lines[1][1]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
     expect(lines[1][2]).toEqual value: " second", scopes: ["source.yaml", "comment.line.number-sign.yaml"]
 

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -294,6 +294,7 @@ describe "YAML grammar", ->
       first: 1st
       second: 2nd
       third: th{ree}
+      fourth:invalid
     """
 
     expect(lines[0][0]).toEqual value: "first", scopes: ["source.yaml", "entity.name.tag.yaml"]
@@ -310,6 +311,8 @@ describe "YAML grammar", ->
     expect(lines[2][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(lines[2][2]).toEqual value: " ", scopes: ["source.yaml"]
     expect(lines[2][3]).toEqual value: "th{ree}", scopes: ["source.yaml", "string.unquoted.yaml"]
+
+    expect(lines[3][0]).toEqual value: "fourth:invalid", scopes: ["source.yaml", "string.unquoted.yaml"]
 
   it "parses quoted keys", ->
     lines = grammar.tokenizeLines """
@@ -404,6 +407,11 @@ describe "YAML grammar", ->
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
     expect(tokens[3]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
     expect(tokens[4]).toEqual value: " This colon breaks syntax highlighting: see?", scopes: ["source.yaml", "comment.line.number-sign.yaml"]
+
+  it "does not confuse keys and unquoted strings", ->
+    {tokens} = grammar.tokenizeLine("- { role: common }")
+    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+    expect(tokens[2]).toEqual value: "{ role: common }", scopes: ["source.yaml", "string.unquoted.yaml"]
 
   it "parses colons in key names", ->
     lines = grammar.tokenizeLines """


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

For some reason whenever I work on language-yaml I end up rewriting the whole thing each time.  Oh well.  This PR should probably have been split up into like 10 different ones, but many of the changes depend on the others.

* Pulled standalone `- stuff` (aka tags without a colon) into its own match
  * This greatly simplifies the main tag match, meaning that we no longer have three nested non-capturing groups
* Ensure that spaces follow the ending colon (fixes the second part of #53)
* Use a consistent blacklist across tag matches (fixes the first part of #53)
  * Note: somehow I messed up the issue number _twice_ in the commit.  The one listed here is correct.
* Fix `constant.other.date.yaml` being misapplied to the entire match, rather than just the date
* Yank date and numeric matching into a repository so that they can be included when necessary, rather than making custom matches for them that would only work under certain scenarios
* Integrate `!!omap` matching into the existing tag matches
* Make variable matching stricter
* Moved many rules (comments, strings, variables) into the repository to reduce code duplication and maintenance
* Properly match non-specific tag indicators (`key: ! value`)
* Don't match leading whitespace as an unquoted string
* Properly match merge-key tags (`<<: *variable-to-merge`)
* Remove old rules that were never used

### Alternate Designs

None.  This is an overall rewrite to the grammar to hopefully make it easier to maintain in the future.  Code duplication was getting out of hand, and many of the more obscure rules weren't working properly.

### Benefits

Better overall code tokenization and accuracy.

### Possible Drawbacks

Possible regressions, as is possible with any rewrite.  Spec coverage has been improving each rewrite though, so the chance of severe regressions happening shouldn't be that large anymore.

### Applicable Issues

Fixes #53