### PR TITLE
Support JSON within YAML

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -16,6 +16,10 @@
 'firstLineMatch': '^(#cloud-config|---)'
 'patterns': [
   {
+    # JSON is YAML
+    'include': 'source.json'
+  }
+  {
     'include': '#erb'
   }
   {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

JSON is YAML, so support it.

### Alternate Designs

None.

### Benefits

JSON syntax will be tokenized correctly.

### Possible Drawbacks

Should be none.

### Applicable Issues

Fixes #5

/cc @envygeeks, @szhu please test this PR out.  I need to know if I need to include JSON support in other places.  For example, should the inside be tokenized as JSON here, or as a YAML unquoted string?
```yaml
a key:
 - { "some_json": "whoa" }
```