### PR TITLE
Don't match escape characters in single quotes

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -259,18 +259,21 @@
         ]
       }
       {
-        'begin': '\''
+        # Per http://www.yaml.org/spec/1.2/spec.html#id2788097, only single quotes can be escaped
+        'begin': "'"
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.yaml'
-        'end': '\''
+        'end': "'"
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.yaml'
         'name': 'string.quoted.single.yaml'
+        'applyEndPatternLast': true
         'patterns': [
           {
-            'include': '#escaped_char'
+            'match': "''"
+            'name': 'constant.character.escape.yaml'
           }
           {
             'include': '#erb'

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -41,26 +41,40 @@ describe "YAML grammar", ->
         expect(tokens[7]).toEqual value: "\\\"", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
         expect(tokens[8]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.end.yaml"]
 
+      it "parses other escape characters", ->
+        {tokens} = grammar.tokenizeLine("\"I am \\escaped\"")
+        expect(tokens[0]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.begin.yaml"]
+        expect(tokens[1]).toEqual value: "I am ", scopes: ["source.yaml", "string.quoted.double.yaml"]
+        expect(tokens[2]).toEqual value: "\\e", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
+        expect(tokens[3]).toEqual value: "scaped", scopes: ["source.yaml", "string.quoted.double.yaml"]
+        expect(tokens[4]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.end.yaml"]
+
     describe "single quoted", ->
-      it "parses escaped quotes", ->
-        {tokens} = grammar.tokenizeLine("'I am \\'escaped\\''")
+      it "parses escaped single quotes", ->
+        {tokens} = grammar.tokenizeLine("'I am ''escaped'''")
         expect(tokens[0]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
         expect(tokens[1]).toEqual value: "I am ", scopes: ["source.yaml", "string.quoted.single.yaml"]
-        expect(tokens[2]).toEqual value: "\\'", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
+        expect(tokens[2]).toEqual value: "''", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
         expect(tokens[3]).toEqual value: "escaped", scopes: ["source.yaml", "string.quoted.single.yaml"]
-        expect(tokens[4]).toEqual value: "\\'", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
+        expect(tokens[4]).toEqual value: "''", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
         expect(tokens[5]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
 
-        {tokens} = grammar.tokenizeLine("key: 'I am \\'escaped\\''")
+        {tokens} = grammar.tokenizeLine("key: 'I am ''escaped'''")
         expect(tokens[0]).toEqual value: "key", scopes: ["source.yaml", "entity.name.tag.yaml"]
         expect(tokens[1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
         expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
         expect(tokens[3]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
         expect(tokens[4]).toEqual value: "I am ", scopes: ["source.yaml", "string.quoted.single.yaml"]
-        expect(tokens[5]).toEqual value: "\\'", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
+        expect(tokens[5]).toEqual value: "''", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
         expect(tokens[6]).toEqual value: "escaped", scopes: ["source.yaml", "string.quoted.single.yaml"]
-        expect(tokens[7]).toEqual value: "\\'", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
+        expect(tokens[7]).toEqual value: "''", scopes: ["source.yaml", "string.quoted.single.yaml", "constant.character.escape.yaml"]
         expect(tokens[8]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
+
+      it "does not recognize backslashes as escape characters", ->
+        {tokens} = grammar.tokenizeLine("'I am not \\escaped'")
+        expect(tokens[0]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
+        expect(tokens[1]).toEqual value: "I am not \\escaped", scopes: ["source.yaml", "string.quoted.single.yaml"]
+        expect(tokens[2]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
 
     describe "text blocks", ->
       it "parses simple content", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

YAML does not treat backslash sequences as escape characters in single-quoted strings.  The only recognized escape character is escaping a single quote via `''`.  So, this PR removes escape character highlighting for single-quoted strings and replaces it with the special-case single-quote escape.

### Alternate Designs

None.

### Benefits

In line with the spec.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #67

Thanks for the report @trejkaz!