### PR TITLE
Add mapping support

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -30,6 +30,9 @@
     'name': 'punctuation.definition.directives.end.yaml'
   }
   {
+    'include': '#mapping'
+  }
+  {
     # hello: >
     # hello: |
     'begin': '^(\\s*)(?!-\\s*)(\\S+)\\s*(:)(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
@@ -232,6 +235,160 @@
   'escaped_char':
     'match': '\\\\.'
     'name': 'constant.character.escape.yaml'
+  'mapping':
+    'begin': '{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.mapping.begin.yaml'
+    'end': '}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.mapping.end.yaml'
+    'name': 'meta.mapping.yaml'
+    'patterns': [
+      {
+        'include': '#mapping'
+      }
+      {
+        'begin': '([^!{@#%&*>,\'"][^#\'"]*?)(:)'
+        'beginCaptures':
+          '1':
+            'name': 'entity.name.tag.yaml'
+          '2':
+            'name': 'punctuation.separator.key-value.yaml'
+        'end': ',|(?=})'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.separator.yaml'
+        'patterns': [
+          {
+            'include': '#mapping-scalar-content'
+          }
+        ]
+      }
+      {
+        'begin': '(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)'
+        'beginCaptures':
+          '1':
+            'name': 'string.quoted.single.yaml'
+          '2':
+            'name': 'punctuation.definition.string.begin.yaml'
+          '3':
+            'name': 'entity.name.tag.yaml'
+          '4':
+            'name': 'punctuation.definition.string.end.yaml'
+          '5':
+            'name': 'string.quoted.double.yaml'
+          '6':
+            'name': 'punctuation.definition.string.begin.yaml'
+          '7':
+            'name': 'entity.name.tag.yaml'
+          '8':
+            'name': 'punctuation.definition.string.end.yaml'
+          '9':
+            'name': 'punctuation.separator.key-value.yaml'
+        'end': ',|(?=})'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.separator.yaml'
+        'patterns': [
+          {
+            'include': '#mapping-scalar-content'
+          }
+        ]
+      }
+    ]
+  'mapping-scalar-content':
+    'patterns': [
+      # This is mostly the same thing as scalar-content, but with an extra (?=[,}]) lookahead added at the end of each rule
+      {
+        'match': '!(?=\\s)'
+        'name': 'punctuation.definition.tag.non-specific.yaml'
+      }
+      {
+        'include': '#mapping'
+      }
+      {
+        'match': '(?<=\\s)(true|false|null)(?=\\s*($|[,}]))'
+        'name': 'constant.language.yaml'
+      }
+      {
+        'match': '([0-9]{4}-[0-9]{2}-[0-9]{2})(?=\\s*($|[,}]))'
+        'captures':
+          '1':
+            'name': 'constant.other.date.yaml'
+      }
+      {
+        'match': '(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)(?=\\s*($|[,}]))'
+        'captures':
+          '1':
+            'name': 'constant.numeric.yaml'
+      }
+      {
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.yaml'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.yaml'
+        'name': 'string.quoted.double.yaml'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#erb'
+          }
+        ]
+      }
+      {
+        # Per http://www.yaml.org/spec/1.2/spec.html#id2788097, only single quotes can be escaped
+        'begin': "'"
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.yaml'
+        'end': "'"
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.yaml'
+        'name': 'string.quoted.single.yaml'
+        'applyEndPatternLast': true
+        'patterns': [
+          {
+            'match': "''"
+            'name': 'constant.character.escape.yaml'
+          }
+          {
+            'include': '#erb'
+          }
+        ]
+      }
+      {
+        'begin': '`'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.yaml'
+        'end': '`'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.yaml'
+        'name': 'string.interpolated.yaml'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#erb'
+          }
+        ]
+      }
+      {
+        'match': '[^\\s"\'\\n](?!\\s*#(?!{))([^,{}#\\n]|((?<!\\s)#))*'
+        'name': 'string.unquoted.yaml'
+      }
+    ]
   'numeric':
     'match': '(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
     'captures':
@@ -312,6 +469,9 @@
       {
         'match': '!(?=\\s)'
         'name': 'punctuation.definition.tag.non-specific.yaml'
+      }
+      {
+        'include': '#mapping'
       }
       {
         'include': '#constants'

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -250,7 +250,7 @@
         'include': '#mapping'
       }
       {
-        'begin': '([^!{@#%&*>,\'"][^#\'"]*?)(:)'
+        'begin': '([^!{@#%&*>,\'"][^#\'"]*?)(:)\\s+'
         'beginCaptures':
           '1':
             'name': 'entity.name.tag.yaml'
@@ -267,6 +267,7 @@
         ]
       }
       {
+        # JSON-like: no spaces are needed after the key
         'begin': '(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)'
         'beginCaptures':
           '1':

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -422,11 +422,6 @@ describe "YAML grammar", ->
     expect(tokens[3]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
     expect(tokens[4]).toEqual value: " This colon breaks syntax highlighting: see?", scopes: ["source.yaml", "comment.line.number-sign.yaml"]
 
-  it "does not confuse keys and unquoted strings", ->
-    {tokens} = grammar.tokenizeLine("- { role: common }")
-    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
-    expect(tokens[2]).toEqual value: "{ role: common }", scopes: ["source.yaml", "string.unquoted.yaml"]
-
   it "parses colons in key names", ->
     lines = grammar.tokenizeLines """
       colon::colon: 1


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds preliminary mapping support based off of the [YAML spec](http://yaml.org/spec/1.2/spec.html#id2790832).

### Alternate Designs

None.

### Benefits

Mappings such as `{key: value, key2: value2}` will not be tokenized properly.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #5