### PR TITLE
Add '.stylelintrc' file support

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -10,6 +10,7 @@
   'yml'
   'yml.erb'
   'sls'
+  'stylelintrc'
   'sublime-syntax'
   'Boxfile'
 ]


### PR DESCRIPTION
From https://stylelint.io/user-guide/configuration/
> The `.stylelintrc` file (without extension) can be in JSON or YAML format.

Note that `.stylintrc` != `.stylelintrc` atom/language-json#56
<!-- Enter any applicable Issues here -->
