### PR TITLE
Fix multiline strings and add document end marker support

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -47,7 +47,7 @@
         'name': 'keyword.other.tag.local.yaml'
       '5':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(?!\\1\\s+)(?=\\s*(-|[^!@#%&*>,].*:\\s+|#))'
+    'end': '^(((?!$)(?!\\1\\s+))|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+)))'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
       {
@@ -77,7 +77,7 @@
         'name': 'keyword.other.tag.local.yaml'
       '7':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(?!\\1 \\4\\s+)(?=\\s*(-|[^!@#%&*>,].*:\\s+|#))'
+    'end': '^(((?!$)(?!\\1\\s+))|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+)))'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
       {
@@ -119,7 +119,7 @@
         'name': 'keyword.other.omap.yaml'
       '6':
         'name': 'punctuation.definition.tag.omap.yaml'
-    'end': '^((?!\\1\\s+)|(?=\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
+    'end': '^((?!\\1\\s+)|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
     'patterns': [
       {
         'include': '#scalar-content'
@@ -156,7 +156,7 @@
         'name': 'keyword.other.omap.yaml'
       '13':
         'name': 'punctuation.definition.tag.omap.yaml'
-    'end': '^((?!\\1\\s+)|(?=\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
+    'end': '^((?!\\1\\s+)|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
     'patterns': [
       {
         'include': '#scalar-content'
@@ -179,7 +179,7 @@
         'name': 'keyword.other.tag.local.yaml'
       '6':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^((?!\\1\\s+)|(?=\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
+    'end': '^((?!\\1\\s+)|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
     'patterns': [
       {
         'include': '#scalar-content'

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -31,6 +31,10 @@
     'name': 'punctuation.definition.directives.end.yaml'
   }
   {
+    'match': '^\\.\\.\\.'
+    'name': 'punctuation.definition.document.end.yaml'
+  }
+  {
     # hello: >
     # hello: |
     'begin': '^(\\s*)(?!-\\s*)(\\S+)\\s*(:)(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
@@ -43,7 +47,7 @@
         'name': 'keyword.other.tag.local.yaml'
       '5':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(?!\\1\\s+)(?=\\s*(-|[^!@#%&*>,].*:|#))'
+    'end': '^(?!\\1\\s+)(?=\\s*(-|[^!@#%&*>,].*:\\s+|#))'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
       {
@@ -73,7 +77,7 @@
         'name': 'keyword.other.tag.local.yaml'
       '7':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(?!\\1 \\4\\s+)(?=\\s*(-|[^!@#%&*>,].*:|#))'
+    'end': '^(?!\\1 \\4\\s+)(?=\\s*(-|[^!@#%&*>,].*:\\s+|#))'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
       {
@@ -103,19 +107,19 @@
     # - hello:
     # look at me go:
     # omap time: !!omap
-    'begin': '(?>^\\s*(-)?\\s*)([^!{@#%&*>,\'"][^#\'"]*?)(:)\\s+((!!)omap)?'
+    'begin': '(?>^(\\s*)(-)?\\s*)([^!{@#%&*>,\'"][^#\'"]*?)(:)\\s+((!!)omap)?'
     'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.entry.yaml'
       '2':
-        'name': 'entity.name.tag.yaml'
+        'name': 'punctuation.definition.entry.yaml'
       '3':
-        'name': 'punctuation.separator.key-value.yaml'
+        'name': 'entity.name.tag.yaml'
       '4':
-        'name': 'keyword.other.omap.yaml'
+        'name': 'punctuation.separator.key-value.yaml'
       '5':
+        'name': 'keyword.other.omap.yaml'
+      '6':
         'name': 'punctuation.definition.tag.omap.yaml'
-    'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
+    'end': '^((?!\\1\\s+)|(?=\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
     'patterns': [
       {
         'include': '#scalar-content'
@@ -126,33 +130,33 @@
     # - 'quoted':
     # "quoted":
     # "with omap": !!omap
-    'begin': '(-)?\\s*(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)\\s+((!!)omap)?'
+    'begin': '^(\\s*)(-)?\\s*(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)\\s+((!!)omap)?'
     'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.entry.yaml'
       '2':
-        'name': 'string.quoted.single.yaml'
+        'name': 'punctuation.definition.entry.yaml'
       '3':
-        'name': 'punctuation.definition.string.begin.yaml'
+        'name': 'string.quoted.single.yaml'
       '4':
-        'name': 'entity.name.tag.yaml'
-      '5':
-        'name': 'punctuation.definition.string.end.yaml'
-      '6':
-        'name': 'string.quoted.double.yaml'
-      '7':
         'name': 'punctuation.definition.string.begin.yaml'
-      '8':
+      '5':
         'name': 'entity.name.tag.yaml'
-      '9':
+      '6':
         'name': 'punctuation.definition.string.end.yaml'
+      '7':
+        'name': 'string.quoted.double.yaml'
+      '8':
+        'name': 'punctuation.definition.string.begin.yaml'
+      '9':
+        'name': 'entity.name.tag.yaml'
       '10':
-        'name': 'punctuation.separator.key-value.yaml'
+        'name': 'punctuation.definition.string.end.yaml'
       '11':
-        'name': 'keyword.other.omap.yaml'
+        'name': 'punctuation.separator.key-value.yaml'
       '12':
+        'name': 'keyword.other.omap.yaml'
+      '13':
         'name': 'punctuation.definition.tag.omap.yaml'
-    'end': '(?=^\\s*(-|[^!{@#%&*>,].*:\\s+))'
+    'end': '^((?!\\1\\s+)|(?=\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
     'patterns': [
       {
         'include': '#scalar-content'
@@ -163,19 +167,19 @@
     # - stuff
     # - !!omap
     # -
-    'begin': '(-)\\s+(?:((!!)omap)|((!)[^!\\s]+)|(?![!@#%&*>,]))'
+    'begin': '^(\\s*)(-)\\s+(?:((!!)omap)|((!)[^!\\s]+)|(?![!@#%&*>,]))'
     'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.entry.yaml'
       '2':
-        'name': 'keyword.other.omap.yaml'
+        'name': 'punctuation.definition.entry.yaml'
       '3':
-        'name': 'punctuation.definition.tag.omap.yaml'
+        'name': 'keyword.other.omap.yaml'
       '4':
-        'name': 'keyword.other.tag.local.yaml'
+        'name': 'punctuation.definition.tag.omap.yaml'
       '5':
+        'name': 'keyword.other.tag.local.yaml'
+      '6':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '(?=^\\s*(-|[^!{@#%&*>,].*:))'
+    'end': '^((?!\\1\\s+)|(?=\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
     'patterns': [
       {
         'include': '#scalar-content'

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -684,13 +684,35 @@ describe "YAML grammar", ->
       {tokens} = grammar.tokenizeLine "true: something"
       expect(tokens[0]).toEqual value: "true", scopes: ["source.yaml", "entity.name.tag.yaml"]
 
-  describe "directives", ->
+  describe "structures", ->
     it "tokenizes directives end markers", ->
       {tokens} = grammar.tokenizeLine "---"
       expect(tokens[0]).toEqual value: "---", scopes: ["source.yaml", "punctuation.definition.directives.end.yaml"]
 
       {tokens} = grammar.tokenizeLine " ---"
       expect(tokens[1]).not.toEqual value: "---", scopes: ["source.yaml", "punctuation.definition.directives.end.yaml"]
+
+    it "tokenizes document end markers", ->
+      {tokens} = grammar.tokenizeLine "..."
+      expect(tokens[0]).toEqual value: "...", scopes: ["source.yaml", "punctuation.definition.document.end.yaml"]
+
+    it "tokenizes structures in an actual YAML document", ->
+      lines = grammar.tokenizeLines """
+        ---
+        time: 20:03:20
+        player: Sammy Sosa
+        action: strike (miss)
+        ...
+        ---
+        time: 20:03:47
+        player: Sammy Sosa
+        action: grand slam
+        ...
+      """
+      expect(lines[0][0]).toEqual value: "---", scopes: ["source.yaml", "punctuation.definition.directives.end.yaml"]
+      expect(lines[4][0]).toEqual value: "...", scopes: ["source.yaml", "punctuation.definition.document.end.yaml"]
+      expect(lines[5][0]).toEqual value: "---", scopes: ["source.yaml", "punctuation.definition.directives.end.yaml"]
+      expect(lines[9][0]).toEqual value: "...", scopes: ["source.yaml", "punctuation.definition.document.end.yaml"]
 
   describe "tabs", ->
     it "marks them as invalid", ->

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -572,7 +572,7 @@ describe "YAML grammar", ->
     lines = grammar.tokenizeLines """
       multiline:
         - 2001-01-01
-        2001-01-01
+          2001-01-01
     """
     expect(lines[1][3]).toEqual value: "2001-01-01", scopes: ["source.yaml", "constant.other.date.yaml"]
     expect(lines[2][1]).toEqual value: "2001-01-01", scopes: ["source.yaml", "constant.other.date.yaml"]
@@ -628,7 +628,7 @@ describe "YAML grammar", ->
     lines = grammar.tokenizeLines """
       multiline:
         - 3.14f
-        3.14f
+          3.14f
     """
     expect(lines[1][3]).toEqual value: "3.14f", scopes: ["source.yaml", "constant.numeric.yaml"]
     expect(lines[2][1]).toEqual value: "3.14f", scopes: ["source.yaml", "constant.numeric.yaml"]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

YAML is tricky because it supports multiline strings using regular tags.  As long as the next line is indented more than the tag, it'll be counted as part of the string.  In previous PRs I implemented the multiline support, but without the indentation requirement.  This PR properly implements indentation checks so that we don't attempt to tokenize _everything_ until the next tag as scalar content.  This fixes embedding (valid) YAML in other grammars, such as GFM.

In addition, the end document marker `...` has been added.

### Alternate Designs

None.

### Benefits

The immediate benefits provided by this PR won't necessarily be evident to people who solely edit YAML because most non-tagged lines will be tokenized as a string anyway.  However, it'll be extremely beneficial to grammars that allow for the embedding of YAML.

### Possible Drawbacks

Not necessarily a drawback, but people don't get any indication that they're writing invalid YAML, even with this pull request.  That is because all lines fall back to being tokenized a string if there are no other matches.  That also makes it extremely hard to test, because the tags don't get an overarching scope name.  So I've had to settle for a document end marker test, which will fail without indentation checks.  This may be something that I'll try to fix for the future.

### Applicable Issues

Fixes #72
Fixes #73

/cc @lierdakil
