### PR TITLE
Add more support for escape sequences

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -231,8 +231,29 @@
       }
     ]
   'escaped_char':
-    'match': '\\\\.'
-    'name': 'constant.character.escape.yaml'
+    # http://yaml.org/spec/1.2/spec.html#id2776092
+    'patterns': [
+      {
+        'match': '\\\\u[A-Fa-f0-9]{4}'
+        'name': 'constant.character.escape.yaml'
+      }
+      {
+        'match': '\\\\U[A-Fa-f0-9]{8}'
+        'name': 'constant.character.escape.yaml'
+      }
+      {
+        'match': '\\\\x\\h{2}'
+        'name': 'constant.character.escape.yaml'
+      }
+      {
+        'match': '\\\\[0abtnvfre "/\\N_LP]' # Space is intentional
+        'name': 'constant.character.escape.yaml'
+      }
+      {
+        'match': '\\\\(u.{4}|U.{8}|x.{2}|.)'
+        'name': 'invalid.illegal.escape.yaml'
+      }
+    ]
   'numeric':
     'match': '(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
     'captures':

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -41,13 +41,46 @@ describe "YAML grammar", ->
         expect(tokens[7]).toEqual value: "\\\"", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
         expect(tokens[8]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.end.yaml"]
 
-      it "parses other escape characters", ->
+      it "parses other escape sequences", ->
         {tokens} = grammar.tokenizeLine("\"I am \\escaped\"")
         expect(tokens[0]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.begin.yaml"]
         expect(tokens[1]).toEqual value: "I am ", scopes: ["source.yaml", "string.quoted.double.yaml"]
         expect(tokens[2]).toEqual value: "\\e", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
         expect(tokens[3]).toEqual value: "scaped", scopes: ["source.yaml", "string.quoted.double.yaml"]
         expect(tokens[4]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.end.yaml"]
+
+        {tokens} = grammar.tokenizeLine('"\\uAb123"')
+        expect(tokens[1]).toEqual value: "\\uAb12", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
+        expect(tokens[2]).toEqual value: "3", scopes: ["source.yaml", "string.quoted.double.yaml"]
+
+        {tokens} = grammar.tokenizeLine('"\\UAb123Fe90"')
+        expect(tokens[1]).toEqual value: "\\UAb123Fe9", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
+        expect(tokens[2]).toEqual value: "0", scopes: ["source.yaml", "string.quoted.double.yaml"]
+
+        {tokens} = grammar.tokenizeLine('"\\x200"')
+        expect(tokens[1]).toEqual value: "\\x20", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
+        expect(tokens[2]).toEqual value: "0", scopes: ["source.yaml", "string.quoted.double.yaml"]
+
+        {tokens} = grammar.tokenizeLine('"\\ hi"')
+        expect(tokens[1]).toEqual value: "\\ ", scopes: ["source.yaml", "string.quoted.double.yaml", "constant.character.escape.yaml"]
+        expect(tokens[2]).toEqual value: "hi", scopes: ["source.yaml", "string.quoted.double.yaml"]
+
+      it "parses invalid escape sequences", ->
+        {tokens} = grammar.tokenizeLine('"\\uqerww"')
+        expect(tokens[1]).toEqual value: "\\uqerw", scopes: ["source.yaml", "string.quoted.double.yaml", "invalid.illegal.escape.yaml"]
+        expect(tokens[2]).toEqual value: "w", scopes: ["source.yaml", "string.quoted.double.yaml"]
+
+        {tokens} = grammar.tokenizeLine('"\\U0123456GF"')
+        expect(tokens[1]).toEqual value: "\\U0123456G", scopes: ["source.yaml", "string.quoted.double.yaml", "invalid.illegal.escape.yaml"]
+        expect(tokens[2]).toEqual value: "F", scopes: ["source.yaml", "string.quoted.double.yaml"]
+
+        {tokens} = grammar.tokenizeLine('"\\x2Q1"')
+        expect(tokens[1]).toEqual value: "\\x2Q", scopes: ["source.yaml", "string.quoted.double.yaml", "invalid.illegal.escape.yaml"]
+        expect(tokens[2]).toEqual value: "1", scopes: ["source.yaml", "string.quoted.double.yaml"]
+
+        {tokens} = grammar.tokenizeLine('"\\c3"')
+        expect(tokens[1]).toEqual value: "\\c", scopes: ["source.yaml", "string.quoted.double.yaml", "invalid.illegal.escape.yaml"]
+        expect(tokens[2]).toEqual value: "3", scopes: ["source.yaml", "string.quoted.double.yaml"]
 
     describe "single quoted", ->
       it "parses escaped single quotes", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Escape sequence tokenization now follows the rules laid out in http://yaml.org/spec/1.2/spec.html#id2776092.

### Alternate Designs

None.

### Benefits

Correct tokenization for escape sequences.

### Possible Drawbacks

While writing a hex or unicode escape sequence, error highlighting will occur until you finish the sequence.

### Applicable Issues

Fixes #75