### PR TITLE
Add support for .yamllint filetype

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -6,6 +6,7 @@
   'eyaml'
   'eyml'
   'yaml'
+  'yamllint',
   'yaml.erb'
   'yml'
   'yml.erb'

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -6,7 +6,7 @@
   'eyaml'
   'eyml'
   'yaml'
-  'yamllint',
+  'yamllint'
   'yaml.erb'
   'yml'
   'yml.erb'


### PR DESCRIPTION
The default YAMLLint configuration file is `.yamllint`.
The configuration itself is YAML.
http://yamllint.readthedocs.io/en/latest/configuration.html