### PR TITLE
Tokenize uppercase variants of true, false, null

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -203,7 +203,7 @@
       '2':
         'name': 'punctuation.definition.comment.yaml'
   'constants':
-    'match': '(?<=\\s)(true|false|null)(?=\\s*$)'
+    'match': '(?<=\\s)(true|false|null|True|False|Null|TRUE|FALSE|NULL|~)(?=\\s*$)'
     'name': 'constant.language.yaml'
   'date':
     'match': '([0-9]{4}-[0-9]{2}-[0-9]{2})\\s*($|(?=#)(?!#{))'

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -707,6 +707,27 @@ describe "YAML grammar", ->
       {tokens} = grammar.tokenizeLine "key: null"
       expect(tokens[3]).toEqual value: "null", scopes: ["source.yaml", "constant.language.yaml"]
 
+      {tokens} = grammar.tokenizeLine "key: True"
+      expect(tokens[3]).toEqual value: "True", scopes: ["source.yaml", "constant.language.yaml"]
+
+      {tokens} = grammar.tokenizeLine "key: False"
+      expect(tokens[3]).toEqual value: "False", scopes: ["source.yaml", "constant.language.yaml"]
+
+      {tokens} = grammar.tokenizeLine "key: Null"
+      expect(tokens[3]).toEqual value: "Null", scopes: ["source.yaml", "constant.language.yaml"]
+
+      {tokens} = grammar.tokenizeLine "key: TRUE"
+      expect(tokens[3]).toEqual value: "TRUE", scopes: ["source.yaml", "constant.language.yaml"]
+
+      {tokens} = grammar.tokenizeLine "key: FALSE"
+      expect(tokens[3]).toEqual value: "FALSE", scopes: ["source.yaml", "constant.language.yaml"]
+
+      {tokens} = grammar.tokenizeLine "key: NULL"
+      expect(tokens[3]).toEqual value: "NULL", scopes: ["source.yaml", "constant.language.yaml"]
+
+      {tokens} = grammar.tokenizeLine "key: ~"
+      expect(tokens[3]).toEqual value: "~", scopes: ["source.yaml", "constant.language.yaml"]
+
       {tokens} = grammar.tokenizeLine "key: true$"
       expect(tokens[3]).toEqual value: "true$", scopes: ["source.yaml", "string.unquoted.yaml"]
 


### PR DESCRIPTION
Also tokenize ~ as an alternative to null

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenize `true`, `false`, `null`, `True`, `False`, `Null`, `TRUE`, `FALSE`, `NULL`, `~` as constants per the [YAML spec](http://yaml.org/spec/1.2/spec.html#id2805071).

### Alternate Designs

Tokenizing other variants, such as `yes` and `no` (#81), but decided not to do so as those are not recognized by the spec.

### Benefits

Closer to the spec.

### Possible Drawbacks

None.

### Applicable Issues

#81