### PR TITLE
Allow quotes inside of unquoted keys

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -108,7 +108,7 @@
     # - hello:
     # look at me go:
     # omap time: !!omap
-    'begin': '(?>^(\\s*)(-)?\\s*)([^!{@#%&*>,\'"][^#\'"]*?)(:)\\s+((!!)omap)?'
+    'begin': '(?>^(\\s*)(-)?\\s*)([^!{@#%&*>,\'"][^#]*?)(:)\\s+((!!)omap)?'
     'beginCaptures':
       '2':
         'name': 'punctuation.definition.entry.yaml'

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -522,6 +522,37 @@ describe "YAML grammar", ->
     expect(lines[2][4]).toEqual value: "3", scopes: ["source.yaml", "string.quoted.double.yaml"]
     expect(lines[2][5]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.end.yaml"]
 
+  it "parses quotes in unquoted key names", ->
+    lines = grammar.tokenizeLines """
+      General Tso's Chicken: 1
+      Dwayne "The Rock" Johnson: 2nd
+      possessives': "3"
+      Conan "the Barbarian": '4'
+    """
+
+    expect(lines[0][0]).toEqual value: "General Tso's Chicken", scopes: ["source.yaml", "entity.name.tag.yaml"]
+    expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.yaml"]
+
+    expect(lines[1][0]).toEqual value: "Dwayne \"The Rock\" Johnson", scopes: ["source.yaml", "entity.name.tag.yaml"]
+    expect(lines[1][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+    expect(lines[1][2]).toEqual value: " ", scopes: ["source.yaml"]
+    expect(lines[1][3]).toEqual value: "2nd", scopes: ["source.yaml", "string.unquoted.yaml"]
+
+    expect(lines[2][0]).toEqual value: "possessives'", scopes: ["source.yaml", "entity.name.tag.yaml"]
+    expect(lines[2][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+    expect(lines[2][2]).toEqual value: " ", scopes: ["source.yaml"]
+    expect(lines[2][3]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.begin.yaml"]
+    expect(lines[2][4]).toEqual value: "3", scopes: ["source.yaml", "string.quoted.double.yaml"]
+    expect(lines[2][5]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.end.yaml"]
+
+    expect(lines[3][0]).toEqual value: "Conan \"the Barbarian\"", scopes: ["source.yaml", "entity.name.tag.yaml"]
+    expect(lines[3][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+    expect(lines[3][2]).toEqual value: " ", scopes: ["source.yaml"]
+    expect(lines[3][3]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
+    expect(lines[3][4]).toEqual value: "4", scopes: ["source.yaml", "string.quoted.single.yaml"]
+    expect(lines[3][5]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
+
   it "parses the merge-key tag", ->
     {tokens} = grammar.tokenizeLine "<<: *variable"
     expect(tokens[0]).toEqual value: "<<", scopes: ["source.yaml", "entity.name.tag.merge.yaml"]

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -145,6 +145,20 @@ describe "YAML grammar", ->
         expect(lines[1][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
         expect(lines[2][0]).toEqual value: "  second line", scopes: ["source.yaml", "string.unquoted.block.yaml"]
 
+      it "parses keys with quotes", ->
+        lines = grammar.tokenizeLines """
+        single'quotes': |
+          content here
+        double"quotes": >
+          content here
+        """
+        expect(lines[0][0]).toEqual value: "single'quotes'", scopes: ["source.yaml", "entity.name.tag.yaml"]
+        expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[1][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+        expect(lines[2][0]).toEqual value: "double\"quotes\"", scopes: ["source.yaml", "entity.name.tag.yaml"]
+        expect(lines[2][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[3][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+
       it "properly parses through pound signs in blocks", ->
         lines = grammar.tokenizeLines """
         key: |

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -159,6 +159,22 @@ describe "YAML grammar", ->
         expect(lines[2][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
         expect(lines[3][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
 
+      it "parses keys with quotes in sequences", ->
+        lines = grammar.tokenizeLines """
+        - single'quotes': |
+          content here
+        - double"quotes": >
+          content here
+        """
+        expect(lines[0][0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+        expect(lines[0][2]).toEqual value: "single'quotes'", scopes: ["source.yaml", "entity.name.tag.yaml"]
+        expect(lines[0][3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[1][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+        expect(lines[2][0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+        expect(lines[2][2]).toEqual value: "double\"quotes\"", scopes: ["source.yaml", "entity.name.tag.yaml"]
+        expect(lines[2][3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[3][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+
       it "properly parses through pound signs in blocks", ->
         lines = grammar.tokenizeLines """
         key: |

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -175,6 +175,22 @@ describe "YAML grammar", ->
         expect(lines[2][3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
         expect(lines[3][0]).toEqual value: "  content here", scopes: ["source.yaml", "string.unquoted.block.yaml"]
 
+      it "parses keys with quotes in sequences even when not using | or >", ->
+        lines = grammar.tokenizeLines """
+        - single'quotes':
+          content here
+        - double"quotes":
+          content here
+        """
+        expect(lines[0][0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+        expect(lines[0][2]).toEqual value: "single'quotes'", scopes: ["source.yaml", "entity.name.tag.yaml"]
+        expect(lines[0][3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[1][1]).toEqual value: "content here", scopes: ["source.yaml", "string.unquoted.yaml"]
+        expect(lines[2][0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+        expect(lines[2][2]).toEqual value: "double\"quotes\"", scopes: ["source.yaml", "entity.name.tag.yaml"]
+        expect(lines[2][3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+        expect(lines[3][1]).toEqual value: "content here", scopes: ["source.yaml", "string.unquoted.yaml"]
+
       it "properly parses through pound signs in blocks", ->
         lines = grammar.tokenizeLines """
         key: |


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Allow quotes inside and after a key if it does not start with a quote.

### Alternate Designs

The grammar was explicitly performing additional, incorrect behavior, so removing this behavior was the only solution.

### Benefits

Compliance with the YAML spec for keys and correct syntax highlighting of keys.

### Possible Drawbacks

None.

### Applicable Issues

Closes #83 
