### PR TITLE
Make the grammar PCRE compatible

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -247,7 +247,7 @@
         'name': 'constant.character.escape.yaml'
       }
       {
-        'match': '\\\\x\\h{2}'
+        'match': '\\\\x[0-9A-Fa-f]{2}'
         'name': 'constant.character.escape.yaml'
       }
       {

--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -251,7 +251,7 @@
         'name': 'constant.character.escape.yaml'
       }
       {
-        'match': '\\\\[0abtnvfre "/\\N_LP]' # Space is intentional
+        'match': '\\\\[0abtnvfre "/\\\\N_LP]' # Space is intentional
         'name': 'constant.character.escape.yaml'
       }
       {


### PR DESCRIPTION
### Description of the Change

This pull request changes 2 regular expressions in an attempt to make the grammar PCRE-compatible. While Atom uses an Oniguruma engine, github.com (which rely on this grammar for YAML highlighting) uses a PCRE-based engine. The two engines interpret `\h` and `\N` differently.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

### Alternate Designs

None considered.

### Benefits

Make the grammar PCRE-compatible. In particular, github.com uses a PCRE engine when it interprets this grammar.
Example for the second change (escaping `N`): [before](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fpchaigno%2Flanguage-yaml%2Fblob%2Fmaster%2Fgrammars%2Fyaml.cson&grammar_text=&code_source=from-text&code_url=&code=test%3A+%22some+string%5C_with+and+escape+sequence%22) and [after](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fpchaigno%2Flanguage-yaml%2Fblob%2Fpcre-compatible%2Fgrammars%2Fyaml.cson&grammar_text=&code_source=from-text&code_url=&code=test%3A+%22some+string%5C_with+and+escape+sequence%22).

### Possible Drawbacks

I don't have any way to check these PCRE vs. Oniguruma discrepancies at the moment. I'm working on a new test at the Linguist-level to check for all known discrepancies.

### References

This was first reported at github/linguist#3635 by @stof.