### PR TITLE
Use begin/end match for comments

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -196,12 +196,12 @@
 ]
 'repository':
   'comment':
-    'match': '(?<=^|\\s)((#(?!{)).*)'
-    'captures':
-      '1':
-        'name': 'comment.line.number-sign.yaml'
-      '2':
+    'begin': '(?<=^|\\s)#(?!{)'
+    'beginCaptures':
+      '0':
         'name': 'punctuation.definition.comment.yaml'
+    'end': '$'
+    'name': 'comment.line.number-sign.yaml'
   'constants':
     'match': '(?<=\\s)(true|false|null|True|False|Null|TRUE|FALSE|NULL|~)(?=\\s*$)'
     'name': 'constant.language.yaml'


### PR DESCRIPTION
Simple fix to allow TODO injections to work.  Same as https://github.com/atom/language-coffee-script/commit/ad0aa553d8f91ca1c4605da0bce5bcaf66c3e2bd

Fixes #89