### PR TITLE
Address multiple issues with comments and multiline tags

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -38,7 +38,7 @@
   {
     # hello: >
     # hello: |
-    'begin': '^(\\s*)(?!-\\s*)(.*\\S)\\s*(:)(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
+    'begin': '^(\\s*)(?!-\\s*)([^!@#%&*>,][^#]*\\S)\\s*(:)(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
     'beginCaptures':
       '2':
         'name': 'entity.name.tag.yaml'
@@ -48,9 +48,19 @@
         'name': 'keyword.other.tag.local.yaml'
       '5':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(((?!$)(?!\\1\\s+))|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+)))'
+    'end': '^(?!$)(?!\\1\\s+)'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
+      {
+        # Comments can only appear on the same line as the tag name
+        'begin': '\\G'
+        'end': '$'
+        'patterns': [
+          {
+            'include': '#comment'
+          }
+        ]
+      }
       {
         'include': '#constants'
       }
@@ -64,23 +74,33 @@
     # - |
     # - hello: >
     # - hello: |
-    'begin': '^(\\s*)(?:(-)|(?:(?:(-)\\s*)?(.*\\S)\\s*(:)))(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
+    'begin': '^(\\s*)(?:(-)|(?:(?:(-)(\\s*))?([^!@#%&*>,][^#]*\\S)\\s*(:)))(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
     'beginCaptures':
       '2':
         'name': 'punctuation.definition.entry.yaml'
       '3':
         'name': 'punctuation.definition.entry.yaml'
-      '4':
-        'name': 'entity.name.tag.yaml'
       '5':
-        'name': 'punctuation.separator.key-value.yaml'
+        'name': 'entity.name.tag.yaml'
       '6':
-        'name': 'keyword.other.tag.local.yaml'
+        'name': 'punctuation.separator.key-value.yaml'
       '7':
+        'name': 'keyword.other.tag.local.yaml'
+      '8':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(((?!$)(?!\\1\\s+))|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+)))'
+    'end': '^((?!$)(?!\\1\\s+)|(?=\\s\\4(-|[^\\s!@#%&*>,].*:\\s+)))'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
+      {
+        # Comments can only appear on the same line as the tag name
+        'begin': '\\G'
+        'end': '$'
+        'patterns': [
+          {
+            'include': '#comment'
+          }
+        ]
+      }
       {
         'include': '#constants'
       }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

There are three issues addressed in this pull request.
1. Comments would be ignored in all parts of a multiline block, including the tag definition itself.  language-yaml now tokenizes comments following a tag definition.
2. Multiline tag definitions would override the comment pattern, resulting in a comment receiving incorrect tag highlighting.  The multiline tag definition regexes have been tweaked to match other similar regexes.
3. Key-like structures in multiline blocks would be tokenized as actual key structures rather than a continuation of the string block.  The end regex has been changed to better match the spec.

### Alternate Designs

None.

### Benefits

Comment + multiline tag interactions will be improved.

### Possible Drawbacks

These regexes just got a whole lot uglier.  I didn't even think that was possible.

### Applicable Issues

Fixes #84
Fixes #92