### PR TITLE
Adding Kaitai `.ksy` extension as `yaml` file.

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -14,6 +14,7 @@
   'stylelintrc'
   'sublime-syntax'
   'Boxfile'
+  'ksy'
 ]
 'firstLineMatch': '^(#cloud-config|---)'
 'patterns': [


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I've added `ksy` extension to the file `grammars/yaml.cson` so that [Kaitai](http://kaitai.io)'s files can be recognized as `yaml` files.

### Alternate Designs

### Benefits

Kaitai's format specification files will be automatically recognized as yaml files. 

### Possible Drawbacks

Another application could use `ksy` extension for files which format is not yaml.

### Applicable Issues

None.