### PR TITLE
Tokenize keys after an unquoted block

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -37,19 +37,25 @@
     'name': 'punctuation.definition.document.end.yaml'
   }
   {
-    # hello: >
-    # hello: |
-    'begin': '^(\\s*)(?!-\\s*)([^!@#%&*>,][^#]*\\S)\\s*(:)(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
+    # - >
+    # - |
+    # - hello: >
+    # - hello: |
+    'begin': '^(\\s*)(?:(-)|(?:(?:(-)(\\s*))?([^!@#%&*>,][^:#]*\\S)\\s*(:)))(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
     'beginCaptures':
       '2':
-        'name': 'entity.name.tag.yaml'
+        'name': 'punctuation.definition.entry.yaml'
       '3':
-        'name': 'punctuation.separator.key-value.yaml'
-      '4':
-        'name': 'keyword.other.tag.local.yaml'
+        'name': 'punctuation.definition.entry.yaml'
       '5':
+        'name': 'entity.name.tag.yaml'
+      '6':
+        'name': 'punctuation.separator.key-value.yaml'
+      '7':
+        'name': 'keyword.other.tag.local.yaml'
+      '8':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(?!$)(?!\\1\\s+)'
+    'end': '^((?!$)(?!\\1\\s+)|(?=\\s\\4(-|[^\\s!@#%&*>,].*:\\s+)))'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
       {
@@ -71,25 +77,19 @@
     ]
   }
   {
-    # - >
-    # - |
-    # - hello: >
-    # - hello: |
-    'begin': '^(\\s*)(?:(-)|(?:(?:(-)(\\s*))?([^!@#%&*>,][^#]*\\S)\\s*(:)))(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
+    # hello: >
+    # hello: |
+    'begin': '^(\\s*)([^!@#%&*>,][^:#]*\\S)\\s*(:)(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
     'beginCaptures':
       '2':
-        'name': 'punctuation.definition.entry.yaml'
-      '3':
-        'name': 'punctuation.definition.entry.yaml'
-      '5':
         'name': 'entity.name.tag.yaml'
-      '6':
+      '3':
         'name': 'punctuation.separator.key-value.yaml'
-      '7':
+      '4':
         'name': 'keyword.other.tag.local.yaml'
-      '8':
+      '5':
         'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^((?!$)(?!\\1\\s+)|(?=\\s\\4(-|[^\\s!@#%&*>,].*:\\s+)))'
+    'end': '^(?!$)(?!\\1\\s+)'
     'contentName': 'string.unquoted.block.yaml'
     'patterns': [
       {

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -435,6 +435,23 @@ describe "YAML grammar", ->
     expect(lines[3][5]).toEqual value: "4th", scopes: ["source.yaml", "string.quoted.double.yaml"]
     expect(lines[3][6]).toEqual value: "\"", scopes: ["source.yaml", "string.quoted.double.yaml", "punctuation.definition.string.end.yaml"]
 
+  it "parses multiple blocks", ->
+    lines = grammar.tokenizeLines """
+      stuff:
+        - long_string: |-
+          hello
+          hello
+        - second_string:
+          - key: b
+    """
+
+    expect(lines[1][1]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+    expect(lines[1][3]).toEqual value: "long_string", scopes: ["source.yaml", "entity.name.tag.yaml"]
+    expect(lines[2][0]).toEqual value: "    hello", scopes: ["source.yaml", "string.unquoted.block.yaml"]
+    expect(lines[4][1]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+    expect(lines[4][3]).toEqual value: "second_string", scopes: ["source.yaml", "entity.name.tag.yaml"]
+    expect(lines[5][1]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+
   it "parses keys and values", ->
     lines = grammar.tokenizeLines """
       first: 1st


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenize keys at the same level of indentation after an unquoted block section.  The diff looks busy, but really all I did was flip the two block patterns so that the one matching dashes has precedence.  There's also a minor optimization to tag name matching where it will now stop upon reaching a colon rather than EOL.

### Alternate Designs

None.

### Benefits

Another YAML bug squashed.

### Possible Drawbacks

Hopefully none - I feel like this makes a ton more sense than trying to keep the previous order where for some reason the less-specific non-dash version was matched before the more-specific dash version.

### Applicable Issues

Fixes #78