### PR TITLE
Rework number tokenization according to the spec

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -281,10 +281,33 @@
       }
     ]
   'numeric':
-    'match': '(((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?)\\s*($|(?=#)(?!#{))'
-    'captures':
-      '1':
-        'name': 'constant.numeric.yaml'
+    # http://www.yaml.org/spec/1.2/spec.html#id2805071
+    'patterns': [
+      {
+        'match': '[-+]?[0-9]+(?=\\s*($|#(?!#{)))'
+        'name': 'constant.numeric.integer.yaml'
+      }
+      {
+        'match': '0o[0-7]+(?=\\s*($|#(?!#{)))'
+        'name': 'constant.numeric.octal.yaml'
+      }
+      {
+        'match': '0x[0-9a-fA-F]+(?=\\s*($|#(?!#{)))'
+        'name': 'constant.numeric.hexadecimal.yaml'
+      }
+      {
+        'match': '[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?(?=\\s*($|#(?!#{)))'
+        'name': 'constant.numeric.float.yaml'
+      }
+      {
+        'match': '[-+]?(\.inf|\.Inf|\.INF)(?=\\s*($|#(?!#{)))'
+        'name': 'constant.numeric.float.yaml'
+      }
+      {
+        'match': '(\.nan|\.NaN|\.NAN)(?=\\s*($|#(?!#{)))'
+        'name': 'constant.numeric.float.yaml'
+      }
+    ]
   'strings':
     'patterns': [
       {

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -798,51 +798,113 @@ describe "YAML grammar", ->
     expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
     expect(tokens[2]).toEqual value: "2001-01-01 uh oh", scopes: ["source.yaml", "string.unquoted.yaml"]
 
-  it "parses numbers", ->
-    {tokens} = grammar.tokenizeLine "- meaning of life: 42"
-    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
-    expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[2]).toEqual value: "meaning of life", scopes: ["source.yaml", "entity.name.tag.yaml"]
-    expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-    expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[5]).toEqual value: "42", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
+  describe "numbers", ->
+    it "parses integers", ->
+      {tokens} = grammar.tokenizeLine "- meaning of life: 42"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "meaning of life", scopes: ["source.yaml", "entity.name.tag.yaml"]
+      expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+      expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[5]).toEqual value: "42", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
-    {tokens} = grammar.tokenizeLine "hex: 0x726Fa"
-    expect(tokens[0]).toEqual value: "hex", scopes: ["source.yaml", "entity.name.tag.yaml"]
-    expect(tokens[1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-    expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[3]).toEqual value: "0x726Fa", scopes: ["source.yaml", "constant.numeric.hexadecimal.yaml"]
+      {tokens} = grammar.tokenizeLine "- positive: +42"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "positive", scopes: ["source.yaml", "entity.name.tag.yaml"]
+      expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+      expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[5]).toEqual value: "+42", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
-    {tokens} = grammar.tokenizeLine "- 0.7e-9001"
-    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
-    expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[2]).toEqual value: "0.7e-9001", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+      {tokens} = grammar.tokenizeLine "- negative: -42"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "negative", scopes: ["source.yaml", "entity.name.tag.yaml"]
+      expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+      expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[5]).toEqual value: "-42", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
-    {tokens} = grammar.tokenizeLine "'over 9000': 9001"
-    expect(tokens[0]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
-    expect(tokens[1]).toEqual value: "over 9000", scopes: ["source.yaml", "string.quoted.single.yaml", "entity.name.tag.yaml"]
-    expect(tokens[2]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
-    expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-    expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[5]).toEqual value: "9001", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
+    it "parses octals", ->
+      {tokens} = grammar.tokenizeLine "octal: 0o664"
+      expect(tokens[0]).toEqual value: "octal", scopes: ["source.yaml", "entity.name.tag.yaml"]
+      expect(tokens[1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+      expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[3]).toEqual value: "0o664", scopes: ["source.yaml", "constant.numeric.octal.yaml"]
 
-    lines = grammar.tokenizeLines """
-      multiline:
-        - 3.14
-          3.14
-    """
-    expect(lines[1][3]).toEqual value: "3.14", scopes: ["source.yaml", "constant.numeric.float.yaml"]
-    expect(lines[2][1]).toEqual value: "3.14", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+    it "parses hexadecimals", ->
+      {tokens} = grammar.tokenizeLine "hex: 0x726Fa"
+      expect(tokens[0]).toEqual value: "hex", scopes: ["source.yaml", "entity.name.tag.yaml"]
+      expect(tokens[1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
+      expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[3]).toEqual value: "0x726Fa", scopes: ["source.yaml", "constant.numeric.hexadecimal.yaml"]
 
-    {tokens} = grammar.tokenizeLine "- pi 3.14"
-    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
-    expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[2]).toEqual value: "pi 3.14", scopes: ["source.yaml", "string.unquoted.yaml"]
+    it "parses floats", ->
+      {tokens} = grammar.tokenizeLine "- 0.7e-9001"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "0.7e-9001", scopes: ["source.yaml", "constant.numeric.float.yaml"]
 
-    {tokens} = grammar.tokenizeLine "- 3.14 uh oh"
-    expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
-    expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[2]).toEqual value: "3.14 uh oh", scopes: ["source.yaml", "string.unquoted.yaml"]
+      {tokens} = grammar.tokenizeLine "- +0.7E-9001"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "+0.7E-9001", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+      {tokens} = grammar.tokenizeLine "- -0.7e9001"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "-0.7e9001", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+    it "parses infinities", ->
+      {tokens} = grammar.tokenizeLine "- .inf"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: ".inf", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+      {tokens} = grammar.tokenizeLine "- -.Inf"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "-.Inf", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+      {tokens} = grammar.tokenizeLine "- +.INF"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "+.INF", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+    it "parses NaNs", ->
+      {tokens} = grammar.tokenizeLine "- .nan"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: ".nan", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+      {tokens} = grammar.tokenizeLine "- .NaN"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: ".NaN", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+      {tokens} = grammar.tokenizeLine "- .NAN"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: ".NAN", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+    it "parses multiple numbers", ->
+      lines = grammar.tokenizeLines """
+        multiline:
+          - 3.14
+            3.14
+      """
+      expect(lines[1][3]).toEqual value: "3.14", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+      expect(lines[2][1]).toEqual value: "3.14", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+
+    it "does not parse numbers surrounded by other characters", ->
+      {tokens} = grammar.tokenizeLine "- pi 3.14"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "pi 3.14", scopes: ["source.yaml", "string.unquoted.yaml"]
+
+      {tokens} = grammar.tokenizeLine "- 3.14 uh oh"
+      expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
+      expect(tokens[2]).toEqual value: "3.14 uh oh", scopes: ["source.yaml", "string.unquoted.yaml"]
 
   describe "variables", ->
     it "tokenizes them", ->

--- a/spec/yaml-spec.coffee
+++ b/spec/yaml-spec.coffee
@@ -425,7 +425,7 @@ describe "YAML grammar", ->
     expect(lines[2][1]).toEqual value: "third", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[2][2]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(lines[2][3]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(lines[2][4]).toEqual value: "3", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(lines[2][4]).toEqual value: "3", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
     expect(lines[3][0]).toEqual value: "    ", scopes: ["source.yaml"]
     expect(lines[3][1]).toEqual value: "fourth", scopes: ["source.yaml", "entity.name.tag.yaml"]
@@ -525,7 +525,7 @@ describe "YAML grammar", ->
 
     expect(lines[0][0]).toEqual value: "first", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
     expect(lines[0][5]).toEqual value: "#", scopes: ["source.yaml", "comment.line.number-sign.yaml", "punctuation.definition.comment.yaml"]
     expect(lines[0][6]).toEqual value: " foo", scopes: ["source.yaml", "comment.line.number-sign.yaml"]
 
@@ -608,7 +608,7 @@ describe "YAML grammar", ->
 
     expect(lines[0][0]).toEqual value: "colon::colon", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
     expect(lines[1][0]).toEqual value: "colon::colon", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[1][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
@@ -645,7 +645,7 @@ describe "YAML grammar", ->
 
     expect(lines[0][0]).toEqual value: "spaced out", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
     expect(lines[1][0]).toEqual value: "more        spaces", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[1][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
@@ -669,7 +669,7 @@ describe "YAML grammar", ->
 
     expect(lines[0][0]).toEqual value: "General Tso's Chicken", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[0][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
-    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(lines[0][3]).toEqual value: "1", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
     expect(lines[1][0]).toEqual value: "Dwayne \"The Rock\" Johnson", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(lines[1][1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
@@ -805,18 +805,18 @@ describe "YAML grammar", ->
     expect(tokens[2]).toEqual value: "meaning of life", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[5]).toEqual value: "42", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(tokens[5]).toEqual value: "42", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
     {tokens} = grammar.tokenizeLine "hex: 0x726Fa"
     expect(tokens[0]).toEqual value: "hex", scopes: ["source.yaml", "entity.name.tag.yaml"]
     expect(tokens[1]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(tokens[2]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[3]).toEqual value: "0x726Fa", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(tokens[3]).toEqual value: "0x726Fa", scopes: ["source.yaml", "constant.numeric.hexadecimal.yaml"]
 
     {tokens} = grammar.tokenizeLine "- 0.7e-9001"
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[2]).toEqual value: "0.7e-9001", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(tokens[2]).toEqual value: "0.7e-9001", scopes: ["source.yaml", "constant.numeric.float.yaml"]
 
     {tokens} = grammar.tokenizeLine "'over 9000': 9001"
     expect(tokens[0]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.begin.yaml"]
@@ -824,15 +824,15 @@ describe "YAML grammar", ->
     expect(tokens[2]).toEqual value: "'", scopes: ["source.yaml", "string.quoted.single.yaml", "punctuation.definition.string.end.yaml"]
     expect(tokens[3]).toEqual value: ":", scopes: ["source.yaml", "punctuation.separator.key-value.yaml"]
     expect(tokens[4]).toEqual value: " ", scopes: ["source.yaml"]
-    expect(tokens[5]).toEqual value: "9001", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(tokens[5]).toEqual value: "9001", scopes: ["source.yaml", "constant.numeric.integer.yaml"]
 
     lines = grammar.tokenizeLines """
       multiline:
-        - 3.14f
-          3.14f
+        - 3.14
+          3.14
     """
-    expect(lines[1][3]).toEqual value: "3.14f", scopes: ["source.yaml", "constant.numeric.yaml"]
-    expect(lines[2][1]).toEqual value: "3.14f", scopes: ["source.yaml", "constant.numeric.yaml"]
+    expect(lines[1][3]).toEqual value: "3.14", scopes: ["source.yaml", "constant.numeric.float.yaml"]
+    expect(lines[2][1]).toEqual value: "3.14", scopes: ["source.yaml", "constant.numeric.float.yaml"]
 
     {tokens} = grammar.tokenizeLine "- pi 3.14"
     expect(tokens[0]).toEqual value: "-", scopes: ["source.yaml", "punctuation.definition.entry.yaml"]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The previous numeric implementation was custom-written and seems to combine YAML's spec with a bit of Java's.  This rewrite makes it conform to the official YAML spec at http://www.yaml.org/spec/1.2/spec.html#id2805071.  Some changes include:
* Removal of support for `3.0f`-style floats
* Removal of support for `0X2`-style hexadecimal integers (`0x2` is still supported)
* Octal support
* Positive/number integer/float support
* Infinity/NaN support

### Alternate Designs

Keep the existing implementation but tweak it to support the additions listed above.  I rejected this because it wouldn't conform to YAML.

### Benefits

See above additions.

### Possible Drawbacks

See above removals.

### Applicable Issues

Fixes #102