### PR TITLE
Remove '---' from firstLineMatch

### DIFF
--- a/grammars/yaml.cson
+++ b/grammars/yaml.cson
@@ -16,7 +16,7 @@
   'Boxfile'
   'ksy'
 ]
-'firstLineMatch': '^(#cloud-config|---)'
+'firstLineMatch': '^#cloud-config'
 'patterns': [
   {
     'include': '#erb'


### PR DESCRIPTION
### Description of the Change
Remove '---' from firstLineMatch. There is no need for it. It is actually a hindrance rather than help because it gobbles up a possible way for YAML sub languages (like Ansible playbooks) to override language-yaml grammar choice. For example they `language-ansible` could use `--- # ansible` or similar but this is not possible because language-yaml matches *everything* using the document separator on first line. Also I can think of at least one other file type that starts with "---" by convention (Jekyll .md templates) so starting with '---' is not very YAML specific.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
Could do `'firstLineMatch': '^(#cloud-config|---)\s*$'` but I don't see any benefit to that.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
As described above: Allow other yaml based grammars to use `---` in their `firstLineMatch`.

### Possible Drawbacks
Will break detection of files that are yaml, start in '---' but don't use one of the numerous file extension matches listed.
